### PR TITLE
Fixed mkrootfs script on Debian-based OS's

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ sudo firecracker/tools/devtool checkenv  # sudo is not needed if you have access
 
 Pyromaniac looks for the VM resources in a `resources` directory. Put the firecracker binary there, either download the [latest release from Github](https://github.com/firecracker-microvm/firecracker/releases/latest), or compile your own copy:
 
-```
+```sh
 firecracker/tools/devtool build --release
 cp firecracker/build/cargo_target/x86_64-unknown-linux-musl/release/firecracker ./resources
 # also copy jailer (see below)
@@ -106,7 +106,7 @@ sudo useradd --system --shell /bin/false firecracker
 The server will by default use jailer instead of just firecracker when compiled with `--release`. Jailer uses certain kernel features to drop privileges for the firecracker binary, which requires that jailer run as root. 
 
 Add the required config settings to the `.env` file:
-```
+```sh
 echo "RESOURCE_PATH=$(pwd)/resources" >> .env  # resource path needs to be the full path
 echo "UID=$(id -u firecracker)" >> .env
 echo "GID=$(id -g firecracker)" >> .env
@@ -115,7 +115,7 @@ echo "PORT=8000" >> .env
 
 Start the server with
 
-```
+```sh
 cargo build --release --bin=pyromaniac 
 sudo target/release/pyromaniac
 ```

--- a/scripts/mkrootfs.sh
+++ b/scripts/mkrootfs.sh
@@ -31,7 +31,7 @@ esac
 cargo build --release --bin=pyrod --target=x86_64-unknown-linux-musl
 
 dd if=/dev/zero of=rootfs.ext4 bs=1M count=$size
-mkfs.ext4 rootfs.ext4
+/usr/sbin/mkfs.ext4 rootfs.ext4
 
 
 sudo rm -rf /tmp/rootfs && mkdir /tmp/rootfs


### PR DESCRIPTION
Previously the mkrootfs.sh script would fail to run on non Ubuntu Debian based operating system's as Debian does not add `/usr/sbin` to the path, see here: https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch03s16.html

This PR fixes it by using the full path to the `mkfs.ext4` utility which is located in `/usr/sbin` .